### PR TITLE
❌ Fix Invalid @Query in RoomRepository (Date + Type Filter)

### DIFF
--- a/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Repo/RoomRepository.java
+++ b/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Repo/RoomRepository.java
@@ -3,6 +3,7 @@ package com.MountainMirage.Hotel_Mountain_Mirage.Repo;
 import com.MountainMirage.Hotel_Mountain_Mirage.Entity.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,9 +18,13 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     @Query("SELECT R FROM Room R WHERE R.id NOT IN (SELECT b.room.id FROM Booking b)")
     List<Room> getAllAvailableRoom();
 
-    @Query("select r from Room r where r.roomType like %:roomType% And r.id not in (select bk.room.id from Booking bk where)" +
-    "(bk.checkInDate <= : checkOutDate) and (bk.checkOutDate >= : checkInDate)")
-    List<Room> findAvailableRoomByDateAndTypes(LocalDate checkInDate, LocalDate checkOutDate, String roomType);
+    @Query("SELECT r FROM Room r WHERE r.roomType LIKE %:roomType% AND r.id NOT IN " +
+            "(SELECT b.room.id FROM Booking b WHERE " +
+            "b.checkInDate <= :checkOutDate AND b.checkOutDate >= :checkInDate)")
+    List<Room> findAvailableRoomByDateAndTypes(@Param("checkInDate") LocalDate checkInDate,
+                                               @Param("checkOutDate") LocalDate checkOutDate,
+                                               @Param("roomType") String roomType);
+
 
 
 }


### PR DESCRIPTION
### 🐞 Bug Description:
The current `@Query` in `RoomRepository` for `findAvailableRoomByDateAndTypes()` is not working and throws a runtime error due to incorrect syntax and parameter binding.

### ❌ Problematic Code:
```java
@Query("select r from Room r where r.roomType like %:roomType% And r.id not in (select bk.room.id from Booking bk where)" +
"(bk.checkInDate <= : checkOutDate) and (bk.checkOutDate >= : checkInDate)")

FIX : 
@Query("SELECT r FROM Room r WHERE r.roomType LIKE %:roomType% AND r.id NOT IN " +
       "(SELECT b.room.id FROM Booking b WHERE " +
       "b.checkInDate <= :checkOutDate AND b.checkOutDate >= :checkInDate)")
List<Room> findAvailableRoomByDateAndTypes(@Param("checkInDate") LocalDate checkInDate,
                                           @Param("checkOutDate") LocalDate checkOutDate,
                                           @Param("roomType") String roomType);