### PR TITLE
Add Register API in AuthController for user registration

### DIFF
--- a/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Controller/AuthController.java
+++ b/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Controller/AuthController.java
@@ -5,6 +5,7 @@ import com.MountainMirage.Hotel_Mountain_Mirage.Dto.LoginRequest;
 import com.MountainMirage.Hotel_Mountain_Mirage.Dto.Response;
 import com.MountainMirage.Hotel_Mountain_Mirage.Entity.User;
 import com.MountainMirage.Hotel_Mountain_Mirage.Service.Interfac.IUserService;
+import jakarta.annotation.security.PermitAll;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,9 +21,17 @@ public class AuthController {
     private IUserService userService;
     @Autowired
     private HandlerMapping resourceHandlerMapping;
+//
+//    @PostMapping("/register")
+//    public ResponseEntity<Response> register(@RequestBody User user){
+//        Response response = userService.register(user);
+//        return ResponseEntity.status(response.getStatusCode()).body(response);
+//    }
 
+
+    @PermitAll
     @PostMapping("/register")
-    public ResponseEntity<Response> register(@RequestBody User user){
+    public ResponseEntity<Response> registerUser(@RequestBody User user) {
         Response response = userService.register(user);
         return ResponseEntity.status(response.getStatusCode()).body(response);
     }

--- a/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Controller/UserController.java
+++ b/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Controller/UserController.java
@@ -2,16 +2,14 @@ package com.MountainMirage.Hotel_Mountain_Mirage.Controller;
 
 
 import com.MountainMirage.Hotel_Mountain_Mirage.Dto.Response;
+import com.MountainMirage.Hotel_Mountain_Mirage.Entity.User;
 import com.MountainMirage.Hotel_Mountain_Mirage.Service.Imp.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.swing.text.html.parser.Entity;
 import java.net.Authenticator;
@@ -54,4 +52,11 @@ public class UserController {
         Response response = userService.getUserBookingHistory(userId);
         return ResponseEntity.status(response.getStatusCode()).body(response);
     }
+
+//    @PostMapping("/register")
+//    public ResponseEntity<Response> registerUser(@RequestBody User user) {
+//        Response response = userService.register(user);
+//        return ResponseEntity.status(response.getStatusCode()).body(response);
+//    }
+
 }

--- a/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Entity/User.java
+++ b/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Entity/User.java
@@ -24,6 +24,7 @@ public class User implements UserDetails {
 
     @NotBlank(message = "Name is Required")
     private String name;
+
     private String PhoneNumber;
 
     @NotBlank(message = "Password is Required")

--- a/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Security/SecurityConfig.java
+++ b/Hotel-Mountain-Mirage/src/main/java/com/MountainMirage/Hotel_Mountain_Mirage/Security/SecurityConfig.java
@@ -30,18 +30,20 @@ public class SecurityConfig {
 
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws  Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
-                .authorizeHttpRequests(request -> request.
-                        requestMatchers("/auth/**", "/rooms/**", "/bookings/**").permitAll()
-                        .anyRequest().authenticated()).
-                sessionManagement(sessionMager -> sessionMager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers("/auth/**", "/rooms/**", "/bookings/**", "/users/register").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sessionMager -> sessionMager.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return httpSecurity.build();
     }
+
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider daoAuthenticationProvider = new DaoAuthenticationProvider();


### PR DESCRIPTION
# Summary
This PR introduces a new **Register API** in the `AuthController` to allow users to register in the system. The API handles user creation, password encryption, and returns a structured response.

# Changes
- Added `POST /auth/register` endpoint in `AuthController`.
- Integrated `UserService.registerUser()` method to save users in the database.
- Applied password encryption using `BCryptPasswordEncoder`.
- Endpoint is publicly accessible (`permitAll`) for new user registration.

# Request Body Example
```json
{
  "email": "test@gmail.com",
  "name": "Mukesh",
  "phoneNumber": "9876543210",
  "password": "123456",
  "role": "ROLE_USER"
}
